### PR TITLE
Updating new file name - service.cache.yml

### DIFF
--- a/integration-tests/src/test/resources/arquillian.xml
+++ b/integration-tests/src/test/resources/arquillian.xml
@@ -7,6 +7,6 @@
     <property name="namespace.use.current">true</property>
     <property name="env.init.enabled">true</property>
     <property name="enableImageStreamDetection">false</property>
-    <property name="env.dependencies">file:../service-cache.yml</property>
+    <property name="env.dependencies">file:../service.cache.yml</property>
   </extension>
 </arquillian>


### PR DESCRIPTION
service.cache.yml is being standardized as the name across all runtime boosters