### PR TITLE
Migrate Fabric8 Maven Plugin to Eclipse JKube OpenShift Maven Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ oc apply -f service.cache.yml
 ```
 3. Deploy the example with:
 ```bash
-mvn fabric8:deploy -Popenshift
+mvn oc:deploy -Popenshift
 ```
 4. Access the exposed route (`greeting-service`) - a HTML page to use the example is exposed.
 

--- a/cute-name-service/pom.xml
+++ b/cute-name-service/pom.xml
@@ -87,12 +87,12 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <version>${fabric8-maven-plugin.version}</version>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
             <executions>
               <execution>
-                <id>fmp</id>
+                <id>jkube</id>
                 <goals>
                   <goal>resource</goal>
                   <goal>build</goal>
@@ -102,12 +102,12 @@
             <configuration>
               <enricher>
                 <excludes>
-                  <exclude>f8-maven-scm</exclude>
+                  <exclude>jkube-maven-scm</exclude>
                 </excludes>
                 <config>
-                  <f8-healthcheck-vertx>
+                  <jkube-healthcheck-vertx>
                     <path>/health</path>
-                  </f8-healthcheck-vertx>
+                  </jkube-healthcheck-vertx>
                 </config>
               </enricher>
               <resources>

--- a/greeting-service/pom.xml
+++ b/greeting-service/pom.xml
@@ -69,12 +69,12 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <version>${fabric8-maven-plugin.version}</version>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
             <executions>
               <execution>
-                <id>fmp</id>
+                <id>jkube</id>
                 <goals>
                   <goal>resource</goal>
                   <goal>build</goal>
@@ -84,12 +84,12 @@
             <configuration>
               <enricher>
                 <excludes>
-                  <exclude>f8-maven-scm</exclude>
+                  <exclude>jkube-maven-scm</exclude>
                 </excludes>
                 <config>
-                  <f8-healthcheck-vertx>
+                  <jkube-healthcheck-vertx>
                     <path>/health</path>
-                  </f8-healthcheck-vertx>
+                  </jkube-healthcheck-vertx>
                 </config>
               </enricher>
               <resources>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -34,9 +35,9 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
-						<version>${fabric8-maven-plugin.version}</version>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<version>${jkube.version}</version>
 						<executions>
 							<execution>
 								<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <fabric8-maven-plugin.version>4.4.1</fabric8-maven-plugin.version>
+    <jkube.version>1.3.0</jkube.version>
     <arquillian-cube.version>1.18.2</arquillian-cube.version>
 
-    <fabric8.generator.from>registry.access.redhat.com/ubi8/openjdk-11</fabric8.generator.from>
+    <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11</jkube.generator.from>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -119,9 +119,9 @@
     <pluginManagement>
       <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <version>${fabric8-maven-plugin.version}</version>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
           </plugin>
       </plugins>
     </pluginManagement>

--- a/service.cache.yml
+++ b/service.cache.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: List
 items:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: cache-server
@@ -16,6 +16,9 @@ items:
       replicas: 1
       strategy:
         type: Recreate
+      selector:
+        matchLabels:
+          app: cache-server  
       template:
         metadata:
           labels:


### PR DESCRIPTION
+ Fabric8 Maven Plugin has been refactored to Eclipse JKube. It is advised
to use Eclipse JKube's OpenShift Maven Plugin instead since all future
development will be done in Eclipse JKube and support for FMP would be
eventually dropped.

+ I tested this on Red Hat Developer Sandbox and noticed that
  `service.cache.yml` is using deprecated `extensions/v1beta1`
  Deployment which is not present on OpenShift 4.x.

   I updated it to `apps/v1` Deployment

Related to openshift-vertx-examples/issues#1